### PR TITLE
change drop database cmd

### DIFF
--- a/lib/apartment/adapters/abstract_adapter.rb
+++ b/lib/apartment/adapters/abstract_adapter.rb
@@ -152,7 +152,7 @@ module Apartment
 
       def drop_command(conn, tenant)
         # connection.drop_database   note that drop_database will not throw an exception, so manually execute
-        conn.execute("DROP DATABASE #{environmentify(tenant)}")
+        conn.execute("DROP DATABASE `#{environmentify(tenant)}`")
       end
 
       class SeparateDbConnectionHandler < ::ActiveRecord::Base


### PR DESCRIPTION
### sql

drop database [Numbers];
drop database 000000;
### error

Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '000000' at line 1: DROP DATABASE 000000
